### PR TITLE
setup github pages for hosting

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,39 @@
+name: Deploy to GitHub Pages
+
+on:
+  # Trigger the workflow every time you push to the `main` branch
+  # Using a different branch name? Replace `main` with your branch’s name
+  push:
+    branches: [ main ]
+  # Allows you to run this workflow manually from the Actions tab on GitHub.
+  workflow_dispatch:
+
+# Allow this job to clone the repo and create a page deployment
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout your repository using git
+        uses: actions/checkout@v4
+      - name: Install, build, and upload your site
+        uses: withastro/action@v3
+        # with:
+          # path: . # The root location of your Astro project inside the repository. (optional)
+          # node-version: 20 # The specific version of Node that should be used to build your site. Defaults to 20. (optional)
+          # package-manager: pnpm@latest # The Node package manager that should be used to install dependencies and build your site. Automatically detected based on your lockfile. (optional)
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/README.md
+++ b/README.md
@@ -1,5 +1,0 @@
-# Personal Website - [harlejwilson.com](https://harleyjwilson.com)
-
-Welcome to the repo for my personal website.
-
-It is modelled on the [Bear Blog](https://bearblog.dev) theme, using [Astro](https://astro.build), and hosted on [Netlify](https://netlify.com).

--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -4,6 +4,7 @@ import { SITE_URL } from "./src/consts";
 
 export default defineConfig({
   site: SITE_URL,
+  base: "skdishansachin.github.io",
   markdown: {
     shikiConfig: {
       theme: "dracula-soft",

--- a/src/consts.ts
+++ b/src/consts.ts
@@ -1,3 +1,3 @@
 export const SITE_TITLE = "skdishansachin";
 export const SITE_DESCRIPTION = "";
-export const SITE_URL = "https://skdishansachin.com";
+export const SITE_URL = "https://skdishansachin.github.io";


### PR DESCRIPTION
This pull request introduces changes to migrate the deployment of the personal website from Cloudflare to GitHub Pages. The most important changes include adding a GitHub Actions workflow for deployment, updating configuration files to reflect the new GitHub Pages URL, and removing outdated references to the previous hosting service.